### PR TITLE
Portability...

### DIFF
--- a/book.c
+++ b/book.c
@@ -233,12 +233,12 @@ void init_b_hash_tables (void) {
 
   // I'll also leave you to test this...
 # ifdef ALTERNATIVE
-# define MB UL << 19
+# define MB * (1UL << 19)
   unsigned long my_max_hash = (32 MB) / b_element_size;
-  while (my_max_hash & -~my_max_hash) // why is this a MUCH better loop, daddeh?
+  while (my_max_hash & -~my_max_hash) // why is this a better loop?
     my_max_hash |= my_max_hash >> i++;
   my_max_hash++;
-  assert(b_max_hash == my_max_hash);
+  assert(b_max_hash == my_max_hash); 
 # endif  
 
   /* allocate our book hash table's memory, and report on the allocation: */


### PR DESCRIPTION
You know, `FILE *` is buffered internally anyway, hence [`setvbuf`](http://pubs.opengroup.org/onlinepubs/9699919799/functions/setvbuf.html)... really you're just duplicating data unnecessarily, but that's beside the point. Food for thought for the future: You could use `mmap` to map the file into your address space, and then you would never need `malloc` or `fread` or anything like that... since it seems you're held back by this invisible wall that is `unsigned long` versus `size_t`, as far as portability is concerned... problem is, you're too far into this project to switch fully to `mmap`, so you're stuck with something that ultimately isn't as portable as it could be.